### PR TITLE
Update symtools.py

### DIFF
--- a/upho/structure/symtools.py
+++ b/upho/structure/symtools.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 import numpy as np
-from phonopy.structure import spglib
+import spglib
 
 
 def get_rotations_cart(atoms):


### PR DESCRIPTION
the line "from phonopy.structure import spglib" throws an error. I checked phonopy.structure and couldn't find spglib there.maybe importing spglib package directly will solve the problem.